### PR TITLE
Added support for using an <a> element with Button

### DIFF
--- a/ui/button.reel/README.md
+++ b/ui/button.reel/README.md
@@ -2,7 +2,7 @@
 
 ![Button](screenshot.png)
 
-The Button component wraps a <button> or <input type="button"> element, and exposes the standard attributes of those elements as properties, which you can use with data binding, for example.
+The Button component wraps a `<button>`, `<input type="button">` or `<a>` element, and exposes the standard attributes of those elements as properties, which you can use with data binding, for example.
 
 ## How to use
 

--- a/ui/button.reel/button.css
+++ b/ui/button.reel/button.css
@@ -1,16 +1,22 @@
+/**
+ * 1. Needed when used with an <a> element
+ */
+
 .digit-Button {
+    display: inline-block; /* 1 */
     outline: none;
     box-sizing: border-box;
     font-size: 16px;
-    height: 2.5em;
     min-width: 2.5em;
     margin: 0 2px;
-    padding: 0 1em;
+    padding: .625em 1em;
     vertical-align: middle;
     border-radius: 24px;
     border: 1px solid #b3b3b3;
     background-color: #f2f2f2;
+    color: hsl(0,0%,30%); /* 1 */
     cursor: pointer;
+    text-decoration: none; /* 1 */
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 

--- a/ui/number-field.reel/number-field.css
+++ b/ui/number-field.reel/number-field.css
@@ -22,7 +22,6 @@
 .digit-NumberField > .digit-NumberField-minus {
     font-size: 16px;
     margin: 0;
-    padding: 2px;
     -webkit-transform: translate3d(0px,0px,0px);
     -moz-transform: translate3d(0px,0px,0px);
     -ms-transform: translate3d(0px,0px,0px);


### PR DESCRIPTION
Sometimes you wanna link out of your app, or to a separate page. So you use an `<a>` but still want to make it look like a "button".

Left `<a>`, right `<button>`
![button-with-a](https://f.cloud.github.com/assets/378023/762379/70a613f0-e7e6-11e2-92a8-f0c97b4a5bb5.png)

ps. There is something off with the number input on the iPad, but I'll wait to fix it since there are already a couple other PRs waiting.

Fixes #16
