### PR TITLE
Fix List scrolling issue

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -2,10 +2,11 @@ require("montage-testing").run(require,[
     // Please keep in alphabetical order
     "test/button/button-spec",
     "test/checkbox/checkbox-spec",
-    "test/slider/slider-spec",
+    "test/list/list-spec",
     "test/number-field/number-field-spec",
     "test/radio-button/radio-button-spec",
     "test/select/select-spec",
+    "test/slider/slider-spec",
     "test/text-field/text-field-spec",
     "test/text-area/text-area-spec",
     "test/toggle-switch/toggle-switch-spec"

--- a/test/list/list-spec.js
+++ b/test/list/list-spec.js
@@ -1,0 +1,55 @@
+var Montage = require("montage").Montage;
+var TestPageLoader = require("montage-testing/testpageloader").TestPageLoader;
+
+TestPageLoader.queueTest("list-test", function(testPage) {
+    var test;
+    beforeEach(function() {
+        test = testPage.test;
+    });
+
+    describe("test/list/list-spec", function() {
+        it("should scroll with the mouse", function() {
+            // a point inside list2
+            var element = testPage.document.elementFromPoint(10, 50);
+
+            // The first dragElementOffsetTo is only needed because the Scroller
+            // only scrolls after the first draw, the first one is used to
+            // calculate the maxTranslateY
+            testPage.dragElementOffsetTo(element, 0, 0, null, null, function() {
+                testPage.waitForDraw();
+                runs(function() {
+
+                    testPage.dragElementOffsetTo(element, 0, -40, null, null, function() {
+                        testPage.waitForDraw();
+                        runs(function() {
+                            expect(testPage.document.elementFromPoint(10, 50)).not.toBe(element);
+                        });
+                    }, {pointerType: "mouse"});
+
+                });
+            }, {pointerType: "mouse"});
+        });
+
+        it("should scroll with touch", function() {
+            // a point inside list2
+            var element = testPage.document.elementFromPoint(10, 50);
+
+            // The first dragElementOffsetTo is only needed because the Scroller
+            // only scrolls after the first draw, the first one is used to
+            // calculate the maxTranslateY
+            testPage.dragElementOffsetTo(element, 0, 0, null, null, function() {
+                testPage.waitForDraw();
+                runs(function() {
+
+                    testPage.dragElementOffsetTo(element, 0, -40, null, null, function() {
+                        testPage.waitForDraw();
+                        runs(function() {
+                            expect(testPage.document.elementFromPoint(10, 50)).not.toBe(element);
+                        });
+                    }, {pointerType: "touch"});
+
+                });
+            }, {pointerType: "touch"});
+        });
+    });
+});

--- a/test/list/list-test.html
+++ b/test/list/list-test.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <script type="text/javascript" src="../../node_modules/montage/montage.js" data-package="../../"></script>
+    <script type="text/montage-serialization">
+        {
+            "test": {
+                "prototype": "test/list/list-test",
+                "properties": {
+                    "list1": {"@": "list1"}
+                }
+            },
+
+            "list1": {
+                "prototype": "ui/list.reel",
+                "properties": {
+                    "element": {"#": "list1"},
+                    "content": [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
+                }
+            },
+
+            "listItem1": {
+                "prototype": "ui/list-item.reel",
+                "properties": {
+                    "element": {"#": "listItem1"}
+                }
+            }
+        }
+    </script>
+    <style>
+        .list1 {
+            height: 100px;
+            width: 100px;
+        }
+    </style>
+</head>
+<body>
+
+<div data-montage-id="list1" class="list1">
+    <p data-montage-id="listItem1">Item</p>
+</div>
+
+</body>
+</html>

--- a/test/list/list-test.js
+++ b/test/list/list-test.js
@@ -1,0 +1,7 @@
+var TestController = require("montage-testing/test-controller").TestController;
+
+exports.ListTest = TestController.specialize({
+    list: {
+        value: null
+    }
+});

--- a/ui/list.reel/list.css
+++ b/ui/list.reel/list.css
@@ -10,6 +10,11 @@
     -webkit-overflow-scrolling: touch;
 }
 
+.digit-List-scroller {
+    width: 100%;
+    height: 100%;
+}
+
 .digit-List-repetition {
     padding: 0;
     margin: 0;

--- a/ui/list.reel/list.html
+++ b/ui/list.reel/list.html
@@ -36,7 +36,7 @@
 </head>
 <body>
 	<div data-montage-id="list" class="digit-List">
-        <div data-montage-id="scroller" class="matte-List-Scroller">
+        <div data-montage-id="scroller" class="digit-List-scroller">
             <ul data-montage-id="repetition" class="digit-List-repetition">
                 <li data-param="*"></li>
             </ul>


### PR DESCRIPTION
A user had to target the Scroller and not the List if it wanted to define the size of the scrollable viewport.
With this change the user can directly target the List.
