### PR TITLE
Slider: the knob gets cut off in Firefox

### DIFF
--- a/ui/slider.reel/slider.css
+++ b/ui/slider.reel/slider.css
@@ -26,6 +26,7 @@
     position: absolute;
     font-size: inherit;
     box-sizing: border-box;
+    -moz-box-sizing: border-box;
     margin: -14px 0 0 -1px;
     border-radius: 14px;
     width: 28px;


### PR DESCRIPTION
![slider-firefox-cut-off](https://f.cloud.github.com/assets/55838/1218922/2cf6d55c-26c2-11e3-8841-bf053ae93078.png)

Firefox 24.0
