### PR TITLE
Run digit tests on Sauce Labs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .DS_Store
 test-results.xml
+sauce_connect*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,71 @@
+module.exports = function(grunt) {
+    var browsers = [{
+        browserName: "firefox",
+        version: "23",
+        platform: "Windows 8"
+    }, {
+        browserName: "chrome",
+        platform: "Windows 8"
+    }, {
+        browserName: "chrome",
+        platform: "linux"
+    }, {
+        browserName: "internet explorer",
+        platform: "WIN8",
+        version: "10"
+    }, {
+        browserName: 'safari',
+        platform: 'OS X 10.8',
+        version: '6'
+    }, {
+        browserName: "iphone",
+        platform: "OS X 10.8",
+        version: '6'
+    }, {
+        browserName: "ipad",
+        platform: "OS X 10.8",
+        version: '6'
+    }, {
+        browserName: 'android',
+        platform: 'Linux',
+        version: '4.0',
+    }, {
+        browserName: 'android',
+        platform: 'Linux',
+        version: '4.0',
+        "device-type": "tablet"
+    }];
+
+    grunt.initConfig({
+        connect: {
+            server: {
+                options: {
+                    base: "",
+                    port: 9999
+                }
+            }
+        },
+        'saucelabs-jasmine': {
+            all: {
+                options: {
+                    urls: ["http://127.0.0.1:9999/run-tests.html"],
+                    tunnelTimeout: 5,
+                    concurrency: 3,
+                    browsers: browsers,
+                    testname: "Digit tests",
+                    testReadyTimeout: 10000,
+                    detailedError: true
+                }
+            }
+        },
+        watch: {}
+    });
+
+    // Loading dependencies
+    for (var key in grunt.file.readJSON("package.json").devDependencies) {
+        if (key !== "grunt" && key.indexOf("grunt") === 0) grunt.loadNpmTasks(key);
+    }
+
+    grunt.registerTask("dev", ["connect", "watch"]);
+    grunt.registerTask("test", ["connect", "saucelabs-jasmine"]);
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "matte": "~0.1.1"
   },
   "devDependencies": {
-    "montage-testing": "~0.2.0"
+    "montage-testing": "~0.2.0",
+    "grunt": "~0.4.1",
+    "grunt-saucelabs": "~4.0.4",
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-watch": "~0.5.3"
   },
   "exclude": [
     "overview.html",

--- a/run-tests.html
+++ b/run-tests.html
@@ -5,10 +5,10 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>
+    <link  href="node_modules/montage-testing/support/jasmine.css" rel="stylesheet" type="text/css" >
     <script src="node_modules/montage-testing/support/jasmine.js"></script>
-    <script src="node_modules/montage-testing/support/js-beautify/beautify.js"></script>
-    <link  href="node_modules/montage-testing/reporter/style.css" rel="stylesheet" type="text/css" >
-    <script src="node_modules/montage-testing/reporter/trivial-html.js"></script>
+    <script src="node_modules/montage-testing/support/jasmine-html.js"></script>
+    <script src="node_modules/montage-testing/support/jasmine-jsreporter.js"></script>
     <script src="node_modules/montage-testing/jasmine-additions.js" ></script>
 
     <script src="node_modules/montage/montage.js" data-module="test/all"></script>


### PR DESCRIPTION
- Test runner uses upgraded jasmine and js and html reporters.
- Configure grunt, various plugins, and desired browsers for Sauce tests.
- Depends on https://github.com/montagejs/montage-testing/pull/7
