### PR TITLE
Deprecate objectAtCurrentIteration in BigList

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/montagejs/digit.git"
   },
   "dependencies": {
-    "montage": "git+http://github.com/montagejs/montage.git#4be249f96f3aa52f955189e6ad0947326f93f7fe",
-    "matte": "~0.1.1"
+    "montage": "git+http://github.com/montagejs/montage.git#master",
+    "matte": "git+http://github.com/montagejs/matte.git#master"
   },
   "devDependencies": {
-    "montage-testing": "~0.2.0"
+    "montage-testing": "~0.3.0"
   },
   "exclude": [
     "overview.html",

--- a/test/big-list/big-list-spec.js
+++ b/test/big-list/big-list-spec.js
@@ -9,6 +9,7 @@ describe("test/big-list/big-list-spec", function() {
         bigList = new BigList();
         bigList.flow = {};
         bigList.flow.didDraw = Function.noop;
+        bigList.flow.observeProperty = Function.noop;
         bigList.flow._repetition = {};
 
         bigList._scrollBars = {};
@@ -128,5 +129,22 @@ describe("test/big-list/big-list-spec", function() {
                 expect(vector[1]).toEqual(-125);
             });
         });
+
+        describe("currentIteration property", function () {
+            it("should cause a deprecation warning", function () {
+                expectConsoleCallsFrom(function () {
+                    bigList.observeProperty("currentIteration", Function.noop, Function.noop );
+                }, window, "warn").toHaveBeenCalledWith("currentIteration is deprecated, use :iteration.object instead.", "");
+            });
+        });
+
+        describe("objectAtCurrentIteration property", function () {
+            it("should cause a deprecation warning", function () {
+                expectConsoleCallsFrom(function () {
+                    bigList.observeProperty("objectAtCurrentIteration", Function.noop, Function.noop );
+                }, window, "warn").toHaveBeenCalledWith("objectAtCurrentIteration is deprecated, use :iteration.object instead.", "");
+            });
+        });
+
     });
 });

--- a/ui/big-list.reel/big-list.js
+++ b/ui/big-list.reel/big-list.js
@@ -5,6 +5,8 @@ var Montage = require("montage").Montage,
     Component = require("montage/ui/component").Component,
     observeProperty = require("montage/frb/observers").observeProperty;
 
+var deprecationWarning = require("montage/core/deprecate").deprecationWarning;
+
 /**
     @class BigList
     @extends Component
@@ -221,6 +223,7 @@ exports.BigList = Component.specialize( /** @lends BigList# */ {
     observeProperty: {
         value: function (key, emit, source, parameters, beforeChange) {
             if (key === "objectAtCurrentIteration" || key === "currentIteration") {
+                deprecationWarning(key,":iteration.object");
                 if (this.flow) {
                     return this.flow.observeProperty(key, emit, source, parameters, beforeChange);
                 }


### PR DESCRIPTION
depends on https://github.com/montagejs/montage/pull/1377
