### PR TITLE
Remove forcing HWA layer by default

### DIFF
--- a/ui/button.reel/button.css
+++ b/ui/button.reel/button.css
@@ -62,11 +62,6 @@
     border-color: hsl(0,0%,80%);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,96%), hsl(0,0%,92%) );
     box-shadow: inset 0 1px 1px hsla(0,0%,100%,.8), inset 0 -1px 1px hsla(0,0%,0%,.04), 0 1px 0 hsla(0,0%,100%,.6);
-
-    -webkit-transform: translate3d(0px,0px,0px);
-    -moz-transform: translate3d(0px,0px,0px);
-    -ms-transform: translate3d(0px,0px,0px);
-    transform: translate3d(0px,0px,0px);
 }
 
 [data-montage-skin="light"] .digit-Button.montage--active {

--- a/ui/number-field.reel/number-field.css
+++ b/ui/number-field.reel/number-field.css
@@ -22,10 +22,6 @@
     float: left;
     margin: 0;
     padding: 2px;
-    -webkit-transform: translate3d(0px,0px,0px);
-    -moz-transform: translate3d(0px,0px,0px);
-    -ms-transform: translate3d(0px,0px,0px);
-    transform: translate3d(0,0,0);
     -webkit-font-smoothing: antialiased;
 }
 

--- a/ui/slider.reel/slider.css
+++ b/ui/slider.reel/slider.css
@@ -82,8 +82,6 @@
     border-color: hsla(0,0%,70%,1);
     background-color: hsl(0,0%,86%);
     box-shadow: inset 0 1px 2px hsla(0,0%,0%,.1), 0 1px 0 hsla(0,0%,100%,.6);
-    -webkit-transform: translate3d(0,0,0);
-    transform: translate3d(0,0,0);
 }
 
 [data-montage-skin="light"] .digit-Slider-thumb {
@@ -106,8 +104,6 @@
     border-color: hsl(0,0%,15%);
     background-color: hsl(0,0%,22%);
     box-shadow: inset 0 1px 2px hsla(0,0%,0%,.25), 0 1px 0 hsla(0,0%,100%,.1);
-    -webkit-transform: translate3d(0,0,0);
-    transform: translate3d(0,0,0);
 }
 
 [data-montage-skin="dark"] .digit-Slider-thumb {

--- a/ui/text-field.reel/text-field.css
+++ b/ui/text-field.reel/text-field.css
@@ -72,11 +72,6 @@
     border-color: hsl(0,0%,80%);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,96%), hsl(0,0%,98%) );
     box-shadow: inset 0 1px 2px hsla(0,0%,0%,.05), 0 1px 0 hsla(0,0%,100%,.6);
-
-    -webkit-transform: translate3d(0px,0px,0px);
-    -moz-transform: translate3d(0px,0px,0px);
-    -ms-transform: translate3d(0px,0px,0px);
-    transform: translate3d(0px,0px,0px);
 }
 
 [data-montage-skin="light"] .digit-TextField:focus {
@@ -100,11 +95,6 @@
     border-color: hsl(0,0%,15%);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,28%), hsl(0,0%,30%) );
     box-shadow: inset 0 1px 2px hsla(0,0%,0%,.1), 0 1px 0 hsla(0,0%,100%,.1);
-
-    -webkit-transform: translate3d(0px,0px,0px);
-    -moz-transform: translate3d(0px,0px,0px);
-    -ms-transform: translate3d(0px,0px,0px);
-    transform: translate3d(0px,0px,0px);
 }
 
 [data-montage-skin="dark"] .digit-TextField:focus {


### PR DESCRIPTION
Some components force a HWA layer by default. I think it's better to do it case by case so this PR removes it.

I think originally it got added because some components got used inside a Flow in the Den Demo? /cc @romancortes? In that case it could be added only to the app's style.css or if it's necessary in all Flows, it could be moved only inside Flow, like:

``` css
.montage-Flow .digit-Button {
    -webkit-transform: translate3d(0,0,0);
    -moz-transform: translate3d(0,0,0);
    -ms-transform: translate3d(0,0,0);
    transform: translate3d(0,0,0);
}
```

Might also be worth looking into the `will-change` property: http://dev.w3.org/csswg/css-will-change/ Still pretty new, but it should eventually replace this zero transform hack.
