### PR TITLE
Fix "double border" of ButtonGroup

### DIFF
--- a/ui/button.reel/button.css
+++ b/ui/button.reel/button.css
@@ -130,15 +130,17 @@
 /* ButtonGroup ---------------------------------------------------------- */
 
 .digit-ButtonGroup {
-    padding-left: 5px; /* Add the negative margin back */
-    font-size: 16px; /* Needed to keep spacing correct */
-    border-radius: 24px;
+    display: inline-block;
+    vertical-align: middle;
+    padding-left: 1px; /* Add the negative margin back */
+    border-radius: 1.25em;
 }
 
 .digit-ButtonGroup > .digit-Button {
+    float: left;
     margin: 0;
+    margin-left: -1px; /* Single border */
     border-radius: 0;
-    margin-left: -5px; /* Remove the space in between */
 }
 
 .digit-ButtonGroup > .digit-Button:first-child {


### PR DESCRIPTION
Fixes following issue: When resizing the browser window (Chrome) the middle borders jump between a single and double border:

![screen shot 2014-06-17 at 1 24 59 pm](https://cloud.githubusercontent.com/assets/378023/3296399/0d6f98f8-f5da-11e3-867e-83c3c41c20f2.png)

Not quite sure why, maybe a rounding error or so.. Anyways.. this PR should fix it to always have only a single pixel border:

![screen shot 2014-06-17 at 1 41 45 pm](https://cloud.githubusercontent.com/assets/378023/3296409/74c5e1d8-f5da-11e3-9c1d-98f84c5be494.png)
